### PR TITLE
Add auto-start on login feature

### DIFF
--- a/js/settings-core.js
+++ b/js/settings-core.js
@@ -11,6 +11,7 @@ const allowRemoteSwitch = document.getElementById('allow-remote-switch');
 const secretKeyInput = document.getElementById('secret-key-input');
 const switchProjectSwitch = document.getElementById('switch-project-switch');
 const switchPreviewModelSwitch = document.getElementById('switch-preview-model-switch');
+const autoStartSwitch = document.getElementById('auto-start-switch');
 
 // Action buttons
 const applyBtn = document.getElementById('apply-btn');
@@ -136,6 +137,49 @@ async function initializeAdditionalSettings() {
         switchPreviewModelSwitch.checked = false;
     }
 }
+
+// Initialize auto-start switch
+async function initializeAutoStart() {
+    try {
+        if (window.__TAURI__?.core?.invoke) {
+            const result = await window.__TAURI__.core.invoke('check_auto_start_enabled');
+            autoStartSwitch.checked = result.enabled || false;
+        }
+    } catch (error) {
+        console.error('Error checking auto-start status:', error);
+        autoStartSwitch.checked = false;
+    }
+}
+
+// Handle auto-start toggle change
+autoStartSwitch.addEventListener('change', async () => {
+    try {
+        if (window.__TAURI__?.core?.invoke) {
+            if (autoStartSwitch.checked) {
+                const result = await window.__TAURI__.core.invoke('enable_auto_start');
+                if (result.success) {
+                    showSuccessMessage('Auto-start enabled successfully');
+                } else {
+                    showError('Failed to enable auto-start');
+                    autoStartSwitch.checked = false;
+                }
+            } else {
+                const result = await window.__TAURI__.core.invoke('disable_auto_start');
+                if (result.success) {
+                    showSuccessMessage('Auto-start disabled successfully');
+                } else {
+                    showError('Failed to disable auto-start');
+                    autoStartSwitch.checked = true;
+                }
+            }
+        }
+    } catch (error) {
+        console.error('Error toggling auto-start:', error);
+        showError('Failed to update auto-start setting');
+        // Revert the toggle
+        autoStartSwitch.checked = !autoStartSwitch.checked;
+    }
+});
 
 // Get current config from server
 async function getCurrentConfig() {

--- a/js/settings-init.js
+++ b/js/settings-init.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await initializeProxyUrl();
         await initializeRemoteManagement();
         await initializeAdditionalSettings();
+        await initializeAutoStart();
         toggleLocalOnlyFields();
         updateServerStatus();
         updateActionButtons();

--- a/settings.html
+++ b/settings.html
@@ -75,6 +75,19 @@
                         </div>
                     </div>
 
+                    <div class="setting-item local-only" id="auto-start-setting">
+                        <div class="setting-label">
+                            <label for="auto-start-switch">Start at Login</label>
+                            <span class="setting-description">Launch EasyCLI automatically when you log in</span>
+                        </div>
+                        <div class="setting-control">
+                            <label class="switch">
+                                <input type="checkbox" id="auto-start-switch" class="switch-input">
+                                <span class="switch-slider"></span>
+                            </label>
+                        </div>
+                    </div>
+
                     <div class="setting-item local-only" id="secret-key-setting">
                         <div class="setting-label">
                             <label for="secret-key-input">Remote Management Secret Key</label>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -959,6 +959,7 @@ dependencies = [
  "tauri-plugin-shell",
  "thiserror 1.0.69",
  "tokio",
+ "winreg 0.52.0",
  "zip",
 ]
 
@@ -973,7 +974,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.5",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -5693,6 +5694,16 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "winreg"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,3 +30,6 @@ rand = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+winreg = "0.52"


### PR DESCRIPTION
## Summary
Implemented platform-specific auto-start functionality to launch EasyCLI automatically when the user logs in.

## Changes
- Added "Start at Login" toggle in Settings UI (Basic Settings tab)
- Implemented backend commands: `check_auto_start_enabled`, `enable_auto_start`, `disable_auto_start`
- Platform-specific implementations:
  - **macOS**: LaunchAgent plist in `~/Library/LaunchAgents/`
  - **Linux**: .desktop file in `~/.config/autostart/`
  - **Windows**: Registry entry in `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run`
- Auto-loads current status on settings page load
- Immediate toggle with success/error feedback
- Added `winreg` dependency for Windows registry support

## Impact
This ensures the application starts automatically after system reboot, improving user experience.