### PR TITLE
fix(linux): stop config watcher feedback loop that reverts unsaved network toggles

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17672,6 +17672,12 @@ fn start_configuration_file_watcher(app: tauri::AppHandle) -> Result<(), String>
     let (sender, receiver) = std::sync::mpsc::channel();
     let mut watcher: RecommendedWatcher =
         notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
+            // Linux inotify also reports access events (e.g. IN_OPEN) for plain
+            // reads. Reacting to them creates a feedback loop because handling a
+            // change re-reads the config files, so only mutations are forwarded.
+            if matches!(&event, Ok(event) if event.kind.is_access()) {
+                return;
+            }
             let _ = sender.send(event);
         })
         .map_err(|error| format!("创建配置文件监控器失败: {error}"))?;

--- a/src/pages/ConfigPanel.tsx
+++ b/src/pages/ConfigPanel.tsx
@@ -85,6 +85,7 @@ export function ConfigPanelPage() {
   const [sessionTtlDraft, setSessionTtlDraft] = useState('');
   const [portError, setPortError] = useState('');
   const [savedStatusVisible, setSavedStatusVisible] = useState(false);
+  const settingsRef = useRef<CoreConfigSettings | null>(null);
   const noticeTimerRef = useRef<number | null>(null);
   const copyTimerRef = useRef<number | null>(null);
 
@@ -93,7 +94,7 @@ export function ConfigPanelPage() {
     let stop: (() => void) | null = null;
     void loadSettings();
     void listen('config-files-changed', () => {
-      if (!disposed) void loadSettings();
+      if (!disposed) void loadSettings('preserve-dirty');
     }).then((unlisten) => {
       if (disposed) unlisten();
       else stop = unlisten;
@@ -121,25 +122,40 @@ export function ConfigPanelPage() {
     }, 3200);
   };
 
-  const applySettings = (result: CoreConfigSettings, syncNetworkDrafts = true) => {
+  type DraftSyncMode = 'sync' | 'preserve-dirty' | 'keep';
+
+  const applySettings = (result: CoreConfigSettings, drafts: DraftSyncMode = 'sync') => {
+    const previous = settingsRef.current;
+    settingsRef.current = result;
     setSettings(result);
-    if (syncNetworkDrafts) {
-      setPortDraft(String(result.port));
-      setAllowLanDraft(result.allowLan);
-      setProxyUrlDraft(result.proxyUrl);
-      setSessionAffinityDraft(result.routingSessionAffinity);
-      setSessionTtlDraft(result.routingSessionAffinityTtl);
+    if (drafts === 'keep') {
+      return;
+    }
+    // On externally triggered reloads keep drafts the user has already edited
+    // so unsaved toggles/inputs are not silently reverted.
+    const base = drafts === 'preserve-dirty' ? previous : null;
+    setPortDraft((draft) => (base && draft !== String(base.port) ? draft : String(result.port)));
+    setAllowLanDraft((draft) => (base && draft !== base.allowLan ? draft : result.allowLan));
+    setProxyUrlDraft((draft) => (base && draft !== base.proxyUrl ? draft : result.proxyUrl));
+    setSessionAffinityDraft((draft) =>
+      base && draft !== base.routingSessionAffinity ? draft : result.routingSessionAffinity,
+    );
+    setSessionTtlDraft((draft) =>
+      base && draft !== base.routingSessionAffinityTtl ? draft : result.routingSessionAffinityTtl,
+    );
+    if (!base) {
       setPortError('');
     }
   };
 
-  async function loadSettings(syncNetworkDrafts = true) {
+  async function loadSettings(drafts: DraftSyncMode = 'sync') {
     setLoading(true);
     setLoadError('');
     try {
       const result = await invoke<CoreConfigSettings>('get_core_config_settings');
-      applySettings(result, syncNetworkDrafts);
+      applySettings(result, drafts);
     } catch (error) {
+      settingsRef.current = null;
       setSettings(null);
       setLoadError(String(error));
     } finally {
@@ -156,14 +172,14 @@ export function ConfigPanelPage() {
     setBusyAction(action);
     try {
       const result = await invoke<CoreConfigSettings>(command, args);
-      applySettings(result, false);
+      applySettings(result, 'keep');
       setLoadError('');
       showNotice(successMessage, 'success');
       return true;
     } catch (error) {
-      if (settings) applySettings(settings, false);
+      if (settings) applySettings(settings, 'keep');
       showNotice(t('config.error.saveFailed', { error: String(error) }), 'error');
-      void loadSettings(false);
+      void loadSettings('keep');
       return false;
     } finally {
       setBusyAction(null);


### PR DESCRIPTION
## 问题 / Problem

Linux 版本中，「高级设置 → 网络与路由」里的开关（如「允许局域网」「会话粘性路由」）
点击后约 1 秒会自动弹回原状态，除非在弹回前抢先点击保存。Windows 无此问题。

On Linux, toggles in Advanced Settings → Network & Routing (e.g. Allow LAN,
session affinity) revert on their own about a second after being clicked,
unless the user manages to press save first. Windows is not affected.

## 原因 / Root cause

`notify` 7 的 inotify 后端会订阅访问类事件（`IN_OPEN` 等），因此在 Linux 上
**仅仅读取** config.yaml 也会触发配置文件监控回调。而后端处理事件时会再次读取
配置文件，前端收到 `config-files-changed` 后调用 `loadSettings()` 又会再读一次，
从而形成自激循环：`config-files-changed` 每约 1 秒持续触发。
`ConfigPanel.tsx` 每次收到事件都会把网络设置草稿重置为磁盘上的值，
导致未保存的开关被不断还原。Windows 的文件监控（ReadDirectoryChangesW）
没有「读取」事件，因此不受影响。

The notify 7 inotify backend also subscribes to access events (`IN_OPEN` etc.),
so merely reading config.yaml fires the watcher. Handling a change re-reads the
config files, and the frontend re-reads them again after receiving
`config-files-changed` — a self-sustaining loop firing roughly every second.
Each cycle resynced the drafts in ConfigPanel, reverting unsaved toggles.

## 修改 / Changes

- **src-tauri/src/main.rs** — 配置文件监控回调忽略 `Access` 类事件，
  只转发修改/创建/删除/重命名（治本）。
  Ignore access events in the configuration watcher callback; only forward
  mutations.
- **src/pages/ConfigPanel.tsx** — 由 `config-files-changed` 触发的刷新改用
  `'preserve-dirty'` 模式：只重置用户未改动的字段，外部配置变化不再悄悄丢弃
  未保存的编辑（兜底，同时也覆盖了智能体配置文件频繁变化的场景）。
  Externally triggered reloads only resync drafts the user has not edited.

## 验证 / Testing

- `cargo check` 与 `tsc --noEmit` 通过（基于 dev 分支）
- Fedora 44 (KDE) 实测：修复前开关约 1 秒自动弹回；修复后开关保持用户
  选择的状态，保存/重启内核流程正常
